### PR TITLE
[필수 과제] CH 4 Spring 리팩터링 및 테스트 개선 (Level 0~4)

### DIFF
--- a/src/main/java/org/example/expert/client/WeatherClient.java
+++ b/src/main/java/org/example/expert/client/WeatherClient.java
@@ -27,13 +27,10 @@ public class WeatherClient {
                 restTemplate.getForEntity(buildWeatherApiUri(), WeatherDto[].class);
 
         WeatherDto[] weatherArray = responseEntity.getBody();
-        if (!HttpStatus.OK.equals(responseEntity.getStatusCode())) {
+        if (!HttpStatus.OK.equals(responseEntity.getStatusCode()))
             throw new ServerException("날씨 데이터를 가져오는데 실패했습니다. 상태 코드: " + responseEntity.getStatusCode());
-        } else {
-            if (weatherArray == null || weatherArray.length == 0) {
-                throw new ServerException("날씨 데이터가 없습니다.");
-            }
-        }
+        if (weatherArray == null || weatherArray.length == 0)
+            throw new ServerException("날씨 데이터가 없습니다.");
 
         String today = getCurrentDate();
 

--- a/src/main/java/org/example/expert/config/AuthUserArgumentResolver.java
+++ b/src/main/java/org/example/expert/config/AuthUserArgumentResolver.java
@@ -1,7 +1,6 @@
 package org.example.expert.config;
 
 import jakarta.servlet.http.HttpServletRequest;
-import lombok.AllArgsConstructor;
 import org.example.expert.domain.auth.exception.AuthException;
 import org.example.expert.domain.common.annotation.Auth;
 import org.example.expert.domain.common.dto.AuthUser;

--- a/src/main/java/org/example/expert/config/AuthUserArgumentResolver.java
+++ b/src/main/java/org/example/expert/config/AuthUserArgumentResolver.java
@@ -1,17 +1,21 @@
 package org.example.expert.config;
 
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.AllArgsConstructor;
 import org.example.expert.domain.auth.exception.AuthException;
 import org.example.expert.domain.common.annotation.Auth;
 import org.example.expert.domain.common.dto.AuthUser;
 import org.example.expert.domain.user.enums.UserRole;
 import org.springframework.core.MethodParameter;
 import org.springframework.lang.Nullable;
+import org.springframework.stereotype.Component;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
+@Component
+@AllArgsConstructor
 public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
 
     @Override

--- a/src/main/java/org/example/expert/config/AuthUserArgumentResolver.java
+++ b/src/main/java/org/example/expert/config/AuthUserArgumentResolver.java
@@ -15,7 +15,6 @@ import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
 @Component
-@AllArgsConstructor
 public class AuthUserArgumentResolver implements HandlerMethodArgumentResolver {
 
     @Override

--- a/src/main/java/org/example/expert/config/JwtUtil.java
+++ b/src/main/java/org/example/expert/config/JwtUtil.java
@@ -21,7 +21,7 @@ import java.util.Date;
 public class JwtUtil {
 
     private static final String BEARER_PREFIX = "Bearer ";
-    private static final long TOKEN_TIME = 60 * 60 * 1000L; // 60분
+    private static final long TOKEN_TIME = 200 * 200 * 1000L; // 60분
 
     @Value("${jwt.secret.key}")
     private String secretKey;

--- a/src/main/java/org/example/expert/config/JwtUtil.java
+++ b/src/main/java/org/example/expert/config/JwtUtil.java
@@ -21,7 +21,7 @@ import java.util.Date;
 public class JwtUtil {
 
     private static final String BEARER_PREFIX = "Bearer ";
-    private static final long TOKEN_TIME = 200 * 200 * 1000L; // 60분
+    private static final long TOKEN_TIME = 200 * 60 * 1000L; // 200분
 
     @Value("${jwt.secret.key}")
     private String secretKey;

--- a/src/main/java/org/example/expert/config/WebConfig.java
+++ b/src/main/java/org/example/expert/config/WebConfig.java
@@ -1,0 +1,20 @@
+package org.example.expert.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthUserArgumentResolver authUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authUserArgumentResolver);
+    }
+}

--- a/src/main/java/org/example/expert/domain/auth/service/AuthService.java
+++ b/src/main/java/org/example/expert/domain/auth/service/AuthService.java
@@ -25,21 +25,19 @@ public class AuthService {
 
     @Transactional
     public SignupResponse signup(SignupRequest signupRequest) {
+        if (userRepository.existsByEmail(signupRequest.getEmail())) {
+            throw new InvalidRequestException("이미 존재하는 이메일입니다.");
+        }
 
         String encodedPassword = passwordEncoder.encode(signupRequest.getPassword());
 
         UserRole userRole = UserRole.of(signupRequest.getUserRole());
 
-        if (userRepository.existsByEmail(signupRequest.getEmail())) {
-            throw new InvalidRequestException("이미 존재하는 이메일입니다.");
-        }
-
-        User newUser = new User(
+        User savedUser = userRepository.save(new User(
                 signupRequest.getEmail(),
                 encodedPassword,
                 userRole
-        );
-        User savedUser = userRepository.save(newUser);
+        ));
 
         String bearerToken = jwtUtil.createToken(savedUser.getId(), savedUser.getEmail(), userRole);
 

--- a/src/main/java/org/example/expert/domain/manager/service/ManagerService.java
+++ b/src/main/java/org/example/expert/domain/manager/service/ManagerService.java
@@ -35,7 +35,7 @@ public class ManagerService {
         Todo todo = todoRepository.findById(todoId)
                 .orElseThrow(() -> new InvalidRequestException("Todo not found"));
 
-        if (!ObjectUtils.nullSafeEquals(user.getId(), todo.getUser().getId())) {
+        if (todo.getUser() == null || !ObjectUtils.nullSafeEquals(user.getId(), todo.getUser().getId())) {
             throw new InvalidRequestException("일정을 생성한 유저만 담당자를 지정할 수 있습니다.");
         }
 

--- a/src/main/java/org/example/expert/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/org/example/expert/domain/todo/repository/TodoRepository.java
@@ -3,6 +3,7 @@ package org.example.expert.domain.todo.repository;
 import org.example.expert.domain.todo.entity.Todo;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,12 +12,12 @@ import java.util.Optional;
 
 public interface TodoRepository extends JpaRepository<Todo, Long> {
 
-    @Query("SELECT t FROM Todo t LEFT JOIN FETCH t.user u ORDER BY t.modifiedAt DESC")
+    @EntityGraph(attributePaths = {"user"})
+    @Query("SELECT t FROM Todo t")
     Page<Todo> findAllByOrderByModifiedAtDesc(Pageable pageable);
 
-    @Query("SELECT t FROM Todo t " +
-            "LEFT JOIN FETCH t.user " +
-            "WHERE t.id = :todoId")
+    @EntityGraph(attributePaths = "user")
+    @Query("SELECT t FROM Todo t WHERE t.id = :todoId")
     Optional<Todo> findByIdWithUser(@Param("todoId") Long todoId);
 
     int countById(Long todoId);

--- a/src/main/java/org/example/expert/domain/todo/repository/TodoRepository.java
+++ b/src/main/java/org/example/expert/domain/todo/repository/TodoRepository.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 public interface TodoRepository extends JpaRepository<Todo, Long> {
 
     @EntityGraph(attributePaths = {"user"})
-    @Query("SELECT t FROM Todo t")
+    @Query("SELECT t FROM Todo t ORDER BY t.modifiedAt DESC")
     Page<Todo> findAllByOrderByModifiedAtDesc(Pageable pageable);
 
     @EntityGraph(attributePaths = "user")

--- a/src/main/java/org/example/expert/domain/todo/service/TodoService.java
+++ b/src/main/java/org/example/expert/domain/todo/service/TodoService.java
@@ -11,6 +11,7 @@ import org.example.expert.domain.todo.entity.Todo;
 import org.example.expert.domain.todo.repository.TodoRepository;
 import org.example.expert.domain.user.dto.response.UserResponse;
 import org.example.expert.domain.user.entity.User;
+import org.example.expert.domain.user.repository.UserRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -20,13 +21,14 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class TodoService {
-
+    private final UserRepository userRepository;
     private final TodoRepository todoRepository;
     private final WeatherClient weatherClient;
 
     @Transactional
     public TodoSaveResponse saveTodo(AuthUser authUser, TodoSaveRequest todoSaveRequest) {
-        User user = User.fromAuthUser(authUser);
+        User user = userRepository.findById(authUser.getId())
+                .orElseThrow(() -> new InvalidRequestException("User not found"));
 
         String weather = weatherClient.getTodayWeather();
 

--- a/src/main/java/org/example/expert/domain/user/controller/UserController.java
+++ b/src/main/java/org/example/expert/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package org.example.expert.domain.user.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.expert.domain.common.annotation.Auth;
 import org.example.expert.domain.common.dto.AuthUser;
@@ -21,7 +22,7 @@ public class UserController {
     }
 
     @PutMapping("/users")
-    public void changePassword(@Auth AuthUser authUser, @RequestBody UserChangePasswordRequest userChangePasswordRequest) {
+    public void changePassword(@Auth AuthUser authUser, @Valid @RequestBody UserChangePasswordRequest userChangePasswordRequest) {
         userService.changePassword(authUser.getId(), userChangePasswordRequest);
     }
 }

--- a/src/main/java/org/example/expert/domain/user/dto/request/UserChangePasswordRequest.java
+++ b/src/main/java/org/example/expert/domain/user/dto/request/UserChangePasswordRequest.java
@@ -1,6 +1,8 @@
 package org.example.expert.domain.user.dto.request;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,6 +14,12 @@ public class UserChangePasswordRequest {
 
     @NotBlank
     private String oldPassword;
+
     @NotBlank
+    @Min(value = 8, message = "새 비밀번호는 8자 이상이어야 합니다")
+    @Pattern(
+            regexp = "^(?=.*[A-Z])(?=.*\\d)$",
+            message = "새 비밀번호는 숫자와 대문자를 포함해야 합니다."
+    )
     private String newPassword;
 }

--- a/src/main/java/org/example/expert/domain/user/dto/request/UserChangePasswordRequest.java
+++ b/src/main/java/org/example/expert/domain/user/dto/request/UserChangePasswordRequest.java
@@ -1,6 +1,5 @@
 package org.example.expert.domain.user.dto.request;
 
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;

--- a/src/main/java/org/example/expert/domain/user/dto/request/UserChangePasswordRequest.java
+++ b/src/main/java/org/example/expert/domain/user/dto/request/UserChangePasswordRequest.java
@@ -13,6 +13,11 @@ import lombok.NoArgsConstructor;
 public class UserChangePasswordRequest {
 
     @NotBlank
+    @Min(value = 8, message = "비밀번호는 8자 이상이어야 합니다")
+    @Pattern(
+            regexp = "^(?=.*[A-Z])(?=.*\\d)$",
+            message = "비밀번호는 숫자와 대문자를 포함해야 합니다."
+    )
     private String oldPassword;
 
     @NotBlank

--- a/src/main/java/org/example/expert/domain/user/dto/request/UserChangePasswordRequest.java
+++ b/src/main/java/org/example/expert/domain/user/dto/request/UserChangePasswordRequest.java
@@ -13,18 +13,16 @@ import lombok.NoArgsConstructor;
 public class UserChangePasswordRequest {
 
     @NotBlank
-    @Min(value = 8, message = "비밀번호는 8자 이상이어야 합니다")
     @Pattern(
-            regexp = "^(?=.*[A-Z])(?=.*\\d)$",
-            message = "비밀번호는 숫자와 대문자를 포함해야 합니다."
+            regexp = "^(?=.*[A-Z])(?=.*\\d).{8,}$",
+            message = "비밀번호는 8자 이상이어야 하고, 숫자와 대문자를 포함해야 합니다."
     )
     private String oldPassword;
 
     @NotBlank
-    @Min(value = 8, message = "새 비밀번호는 8자 이상이어야 합니다")
     @Pattern(
-            regexp = "^(?=.*[A-Z])(?=.*\\d)$",
-            message = "새 비밀번호는 숫자와 대문자를 포함해야 합니다."
+            regexp = "^(?=.*[A-Z])(?=.*\\d).{8,}$",
+            message = "새 비밀번호는 8자 이상이어야 하고, 숫자와 대문자를 포함해야 합니다."
     )
     private String newPassword;
 }

--- a/src/main/java/org/example/expert/domain/user/service/UserService.java
+++ b/src/main/java/org/example/expert/domain/user/service/UserService.java
@@ -25,11 +25,11 @@ public class UserService {
 
     @Transactional
     public void changePassword(long userId, UserChangePasswordRequest userChangePasswordRequest) {
-        if (userChangePasswordRequest.getNewPassword().length() < 8 ||
-                !userChangePasswordRequest.getNewPassword().matches(".*\\d.*") ||
-                !userChangePasswordRequest.getNewPassword().matches(".*[A-Z].*")) {
-            throw new InvalidRequestException("새 비밀번호는 8자 이상이어야 하고, 숫자와 대문자를 포함해야 합니다.");
-        }
+//        if (userChangePasswordRequest.getNewPassword().length() < 8 ||
+//                !userChangePasswordRequest.getNewPassword().matches(".*\\d.*") ||
+//                !userChangePasswordRequest.getNewPassword().matches(".*[A-Z].*")) {
+//            throw new InvalidRequestException("새 비밀번호는 8자 이상이어야 하고, 숫자와 대문자를 포함해야 합니다.");
+//        }
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new InvalidRequestException("User not found"));

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,6 @@ spring:
       hibernate:
         format_sql: true
 
-  jwt:
-    secret:
-      key: ${JWT_SECRET_KEY}
+jwt:
+  secret:
+    key: ${JWT_SECRET_KEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/debug
+    username: yeang
+    password: ${DATABASE_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+  jwt:
+    secret:
+      key: ${JWT_SECRET_KEY}

--- a/src/test/java/org/example/expert/config/PasswordEncoderTest.java
+++ b/src/test/java/org/example/expert/config/PasswordEncoderTest.java
@@ -20,7 +20,7 @@ class PasswordEncoderTest {
         String encodedPassword = passwordEncoder.encode(rawPassword);
 
         // when
-        boolean matches = passwordEncoder.matches(encodedPassword, rawPassword);
+        boolean matches = passwordEncoder.matches(rawPassword, encodedPassword);
 
         // then
         assertTrue(matches);

--- a/src/test/java/org/example/expert/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/org/example/expert/domain/comment/service/CommentServiceTest.java
@@ -5,6 +5,7 @@ import org.example.expert.domain.comment.dto.response.CommentSaveResponse;
 import org.example.expert.domain.comment.entity.Comment;
 import org.example.expert.domain.comment.repository.CommentRepository;
 import org.example.expert.domain.common.dto.AuthUser;
+import org.example.expert.domain.common.exception.InvalidRequestException;
 import org.example.expert.domain.common.exception.ServerException;
 import org.example.expert.domain.todo.entity.Todo;
 import org.example.expert.domain.todo.repository.TodoRepository;
@@ -43,7 +44,7 @@ class CommentServiceTest {
         given(todoRepository.findById(anyLong())).willReturn(Optional.empty());
 
         // when
-        ServerException exception = assertThrows(ServerException.class, () -> {
+        InvalidRequestException exception = assertThrows(InvalidRequestException.class, () -> {
             commentService.saveComment(authUser, todoId, request);
         });
 

--- a/src/test/java/org/example/expert/domain/manager/service/ManagerServiceTest.java
+++ b/src/test/java/org/example/expert/domain/manager/service/ManagerServiceTest.java
@@ -39,14 +39,14 @@ class ManagerServiceTest {
     private ManagerService managerService;
 
     @Test
-    public void manager_목록_조회_시_Todo가_없다면_NPE_에러를_던진다() {
+    public void manager_목록_조회_시_Todo가_없다면_IRE_에러를_던진다() {
         // given
         long todoId = 1L;
         given(todoRepository.findById(todoId)).willReturn(Optional.empty());
 
         // when & then
         InvalidRequestException exception = assertThrows(InvalidRequestException.class, () -> managerService.getManagers(todoId));
-        assertEquals("Manager not found", exception.getMessage());
+        assertEquals("Todo not found", exception.getMessage());
     }
 
     @Test


### PR DESCRIPTION
## 📌 개요

CH 4 심화 Spring 과제의 필수 단계 Level 0~4를 수행했습니다.

중첩 조건문과 불필요한 로직을 정리하고, DTO Validation 적용, N+1 문제 개선, 예외 처리 및 테스트 코드 수정을 진행했습니다.

## 🔧 주요 변경 사항

### Level 0. 프로젝트 설정

- MySQL 및 JWT 설정을 위한 `application.yml` 추가
- DB 비밀번호와 JWT Secret Key를 환경변수로 분리

### Level 1. ArgumentResolver 설정

- `AuthUserArgumentResolver`를 Spring Bean으로 등록
- 누락된 `WebConfig`를 복구하고 ArgumentResolver 등록

### Level 2-1. 인증 로직 선검증

- 회원가입 시 이메일 중복 여부를 비밀번호 인코딩보다 먼저 검사
- 저장할 사용자 객체의 불필요한 중간 변수 제거
- 사용자 저장 로직 단순화

### Level 2-2. 불필요한 if-else 제거

- `WeatherClient`의 중첩 `if-else` 제거
- 예외 발생 조건을 Guard Clause 형태로 분리
- 정상 실행 흐름의 가독성 개선

### Level 2-3. 비밀번호 Validation 적용

- 비밀번호 변경 요청에 `@Valid` 적용
- `@NotBlank`, `@Pattern`을 이용해 다음 조건 검증
  - 8자 이상
  - 대문자 포함
  - 숫자 포함
- 서비스 계층에서 처리하던 수동 검증을 DTO Validation으로 이동

### Level 3. N+1 문제 개선

- `TodoRepository` 조회 메서드에 `@EntityGraph` 적용
- Todo 목록 및 단건 조회 시 연관된 User를 함께 조회
- Todo 생성 시 인증 정보로 임시 객체를 만들지 않고 실제 User 엔티티 조회
- JWT 토큰 유효시간 조정

### Level 4-1. 성공 테스트 수정

- `PasswordEncoder.matches()`의 인수 순서를 다음과 같이 수정

```java
passwordEncoder.matches(rawPassword, encodedPassword);
```

### Level 4-2. 예외 테스트 및 서비스 로직 수정

- Todo가 존재하지 않을 때의 예외 메시지를 `Todo not found`로 수정
- Comment 생성 테스트의 예상 예외를 `InvalidRequestException`으로 변경
- `Todo.user`가 `null`인 경우를 먼저 검사하도록 ManagerService 수정

```java
if (todo.getUser() == null
        || !ObjectUtils.nullSafeEquals(
                user.getId(),
                todo.getUser().getId()
        )) {
    throw new InvalidRequestException(
            "일정을 생성한 유저만 담당자를 지정할 수 있습니다."
    );
}
```

- `||`의 단락 평가를 이용해 `todo.getUser()`가 `null`이면 뒤쪽 ID 비교를 실행하지 않도록 처리
- 의도하지 않은 `NullPointerException` 대신 도메인 예외 반환

## 🧪 수정한 테스트

- `PasswordEncoderTest`
- `CommentServiceTest`
- `ManagerServiceTest`

## ✅ 제출 전 확인 사항

- [x] 전체 테스트 실행 및 통과 확인
- [x] `DATABASE_PASSWORD` 환경변수 설정
- [x] `JWT_SECRET_KEY` 환경변수 설정
- [x] 애플리케이션 정상 실행 확인