### PR TITLE
[필수 과제] CH 4 Spring 리팩터링 및 테스트 개선 (Level 0~4)

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/debug
+    username: yeang
+    password: ${DATABASE_PASSWORD}
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+  jwt:
+    secret:
+      key: ${JWT_SECRET_KEY}


### PR DESCRIPTION
## 📌 개요

CH 4 심화 Spring 과제의 필수 단계 Level 0~4를 수행했습니다.

중첩 조건문과 불필요한 로직을 정리하고, DTO Validation 적용, N+1 문제 개선, 예외 처리 및 테스트 코드 수정을 진행했습니다.

## 🔧 주요 변경 사항

### Level 0. 프로젝트 설정

- MySQL 및 JWT 설정을 위한 `application.yml` 추가
- DB 비밀번호와 JWT Secret Key를 환경변수로 분리

### Level 1. ArgumentResolver 설정

- `AuthUserArgumentResolver`를 Spring Bean으로 등록
- 누락된 `WebConfig`를 복구하고 ArgumentResolver 등록

### Level 2-1. 인증 로직 선검증

- 회원가입 시 이메일 중복 여부를 비밀번호 인코딩보다 먼저 검사
- 저장할 사용자 객체의 불필요한 중간 변수 제거
- 사용자 저장 로직 단순화

### Level 2-2. 불필요한 if-else 제거

- `WeatherClient`의 중첩 `if-else` 제거
- 예외 발생 조건을 Guard Clause 형태로 분리
- 정상 실행 흐름의 가독성 개선

### Level 2-3. 비밀번호 Validation 적용

- 비밀번호 변경 요청에 `@Valid` 적용
- `@NotBlank`, `@Pattern`을 이용해 다음 조건 검증
  - 8자 이상
  - 대문자 포함
  - 숫자 포함
- 서비스 계층에서 처리하던 수동 검증을 DTO Validation으로 이동

### Level 3. N+1 문제 개선

- `TodoRepository` 조회 메서드에 `@EntityGraph` 적용
- Todo 목록 및 단건 조회 시 연관된 User를 함께 조회
- Todo 생성 시 인증 정보로 임시 객체를 만들지 않고 실제 User 엔티티 조회
- JWT 토큰 유효시간 조정

### Level 4-1. 성공 테스트 수정

- `PasswordEncoder.matches()`의 인수 순서를 다음과 같이 수정

```java
passwordEncoder.matches(rawPassword, encodedPassword);
```

### Level 4-2. 예외 테스트 및 서비스 로직 수정

- Todo가 존재하지 않을 때의 예외 메시지를 `Todo not found`로 수정
- Comment 생성 테스트의 예상 예외를 `InvalidRequestException`으로 변경
- `Todo.user`가 `null`인 경우를 먼저 검사하도록 ManagerService 수정

```java
if (todo.getUser() == null
        || !ObjectUtils.nullSafeEquals(
                user.getId(),
                todo.getUser().getId()
        )) {
    throw new InvalidRequestException(
            "일정을 생성한 유저만 담당자를 지정할 수 있습니다."
    );
}
```

- `||`의 단락 평가를 이용해 `todo.getUser()`가 `null`이면 뒤쪽 ID 비교를 실행하지 않도록 처리
- 의도하지 않은 `NullPointerException` 대신 도메인 예외 반환

## 🧪 수정한 테스트

- `PasswordEncoderTest`
- `CommentServiceTest`
- `ManagerServiceTest`

## ✅ 제출 전 확인 사항

- [ ] 전체 테스트 실행 및 통과 확인
- [ ] `DATABASE_PASSWORD` 환경변수 설정
- [ ] `JWT_SECRET_KEY` 환경변수 설정
- [ ] 애플리케이션 정상 실행 확인